### PR TITLE
Add Dockerfile and k8s config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM python:2.7.11-onbuild
+CMD ["python", "run.py"]

--- a/k8s.yaml
+++ b/k8s.yaml
@@ -1,0 +1,33 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  namespace: peter-darts
+  name: elo-py
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: elo-py
+    spec:
+      imagePullSecrets:
+        - name: ecr
+      containers:
+      - name: elo
+        image: 841163038363.dkr.ecr.us-east-1.amazonaws.com/nrmitchi/cratejoy:peter-4
+        ports:
+        - containerPort: 5000
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: darts-service
+spec:
+  type: LoadBalancer
+  selector:
+    app: elo-py
+  ports:
+  - port: 80
+    targetPort: 5000

--- a/run.py
+++ b/run.py
@@ -1,3 +1,3 @@
 #!flask/bin/python
 from app import app
-app.run(debug=True)
+app.run(host='0.0.0.0', debug=True)


### PR DESCRIPTION
Changes from the hackathon, note that to build this image you need a config.py that includes the DB config for your prod db. If you change this to pull environment variables you could add those variables to the k8s.yaml file in this PR instead.